### PR TITLE
Don't singularize the type

### DIFF
--- a/addon/computed.js
+++ b/addon/computed.js
@@ -1,19 +1,16 @@
 import Ember from 'ember';
 
-import { normalizeType } from 'ember-can/utils/normalize';
-
 var get = Ember.get;
 var set = Ember.set;
 
 export default {
-  ability: function(typeName, resourceName) {
+  ability: function(type, resourceName) {
     if (arguments.length === 1) {
-      resourceName = typeName;
+      resourceName = type;
     }
 
     return Ember.computed(resourceName, function() {
       var container = this.container;
-      var type      = normalizeType(typeName);
       var ability   = container.lookup("ability:"+type);
 
       Ember.assert("No ability class found for "+type, ability);

--- a/addon/utils/normalize.js
+++ b/addon/utils/normalize.js
@@ -14,8 +14,7 @@ var stopwords = [
 export function normalizeCombined(abilityName) {
   var parts   = abilityName.split(' ');
 
-  var typeStr = parts.pop();
-  var type    = normalizeType(typeStr);
+  var type = parts.pop();
 
   var last = parts[parts.length-1];
   if (stopwords.indexOf(last) !== -1) {
@@ -32,8 +31,4 @@ export function normalizeCombined(abilityName) {
 
 export function normalizeAbility(ability) {
   return 'can'+classify(ability);
-}
-
-export function normalizeType(type) {
-  return singularize(type);
 }

--- a/addon/utils/normalize.js
+++ b/addon/utils/normalize.js
@@ -2,11 +2,6 @@ import Ember from 'ember';
 
 var classify    = Ember.String.classify;
 
-// singularize comes with Ember Inflector / Ember Data
-var singularize = Ember.String.singularize || function(str) {
-  return str.replace(/s$/, '');
-};
-
 var stopwords = [
   "of", "in", "for", "to", "from"
 ];

--- a/tests/unit/utils/normalize-test.js
+++ b/tests/unit/utils/normalize-test.js
@@ -5,7 +5,6 @@ import {
 import {
   normalizeCombined,
   normalizeAbility,
-  normalizeType
 } from 'ember-can/utils/normalize';
 
 module('normalize');
@@ -42,8 +41,4 @@ test('removes stopwords from combined string', function() {
 
 test('normalizes abilities', function() {
   equal(normalizeAbility("manage members"), "canManageMembers", "prepends can and camelizes");
-});
-
-test('normalizes types', function() {
-  equal(normalizeType("posts"), "post", "singularizes the type");
 });


### PR DESCRIPTION
Depending on your structure this might not be the right thing to do.
If you name your ability `posts.js` or using the pod structyre it
lives in `posts/ability.js` the helper will be `{{if (can "write posts")}}`

If you name your file in a singular way it will be `{{if (can "write post"}}`
as it used to be.