### PR TITLE
Reopen the resolver to add abilities.

### DIFF
--- a/app/initializers/setup-ember-can.js
+++ b/app/initializers/setup-ember-can.js
@@ -1,14 +1,16 @@
-import config from '../config/environment';
+import Resolver from 'ember/resolver';
+
+Resolver.reopen({
+  pluralizedTypes: {
+    ability: 'abilities'
+  }
+});
 
 export default {
   name: 'setup-ember-can',
-  initialize: function(container, application) {
+  initialize: function(container) {
 
     // make sure we create new ability instances each time, otherwise we stomp on each other's models
     container.optionsForType('ability', { singleton: false });
-
-    // add pluralization rule for activity -> activities to the resolver
-    // TODO - update this when there's a better way of accessing the resolver
-    container.resolver.__resolver__.pluralizedTypes['ability'] = 'abilities';
   }
 };


### PR DESCRIPTION
This seems to be a better way than accessing it using an __method__. I found this method in [ember-sanctify](https://github.com/wildland/ember-sanctify/blob/fd316d454cf93bb10aaca05c2a7a3abacd0b6b6f/app/initializers/setup-policy-pluralization.js).