### PR TITLE
Corrected Ember.computed.reads syntax in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ export default Ember.Controller.extend({
   ability: computed.ability('post'),
 
   // alias properties to the ability for easier access
-  canEditPost: Ember.computed.reads('ability', 'canEdit')
+  canEditPost: Ember.computed.reads('ability.canEdit')
 });
 ```
 


### PR DESCRIPTION
It seems that `Ember.computed.reads` accepts only one argument: http://emberjs.com/api/classes/Ember.computed.html#method_reads