### PR TITLE
Use new ember-resolver instead of ember/resolver

### DIFF
--- a/app/initializers/setup-ember-can.js
+++ b/app/initializers/setup-ember-can.js
@@ -1,4 +1,4 @@
-import Resolver from 'ember/resolver';
+import Resolver from 'ember-resolver';
 
 Resolver.reopen({
   pluralizedTypes: {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.3",
     "ember-disable-prototype-extensions": "^1.0.0",
-    "ember-try": "0.0.6"
+    "ember-try": "0.0.6",
+    "ember-resolver": "2.0.3"
   },
   "keywords": [
     "ember-addon",

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import Resolver from 'ember/resolver';
+import Resolver from 'ember-resolver';
 import loadInitializers from 'ember/load-initializers';
 import config from './config/environment';
 

--- a/tests/helpers/resolver.js
+++ b/tests/helpers/resolver.js
@@ -1,4 +1,4 @@
-import Resolver from 'ember/resolver';
+import Resolver from 'ember-resolver';
 import config from '../../config/environment';
 
 var resolver = Resolver.create();


### PR DESCRIPTION
This should remove the deprecation warning in the latest Ember release v2.2.0.

I only tested against 2.2.0, I will test against the older version later today, I just wanted to file the pull request to make sure I don't forget it later on.