### PR TITLE
Rely on getOwner polyfill

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,6 @@ cache:
   directories:
     - node_modules
 
-env:
-  - EMBER_TRY_SCENARIO=default
-  - EMBER_TRY_SCENARIO=ember-release
-  - EMBER_TRY_SCENARIO=ember-beta
-  - EMBER_TRY_SCENARIO=ember-canary
-
 matrix:
   fast_finish: true
   allow_failures:
@@ -31,4 +25,4 @@ install:
   - bower install
 
 script:
-  - ember try $EMBER_TRY_SCENARIO test
+  - ember try:each

--- a/addon/can-mixin.js
+++ b/addon/can-mixin.js
@@ -1,10 +1,10 @@
 import Ember from 'ember';
 
 export default Ember.Mixin.create({
-  canService: Ember.inject.service("can"),
+  canService: Ember.inject.service('can'),
 
   can: function(abilityName, resource, aditionalProperties) {
-    return this.get("canService").can(abilityName, resource, aditionalProperties);
+    return this.get('canService').can(abilityName, resource, aditionalProperties);
   },
 
   cannot: function(abilityName, resource, aditionalProperties) {

--- a/addon/computed.js
+++ b/addon/computed.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import getOwner from 'ember-getowner-polyfill';
 
 const { get, set } = Ember;
 
@@ -9,12 +10,12 @@ export default {
     }
 
     return Ember.computed(resourceName, function() {
-      const ability = Ember.getOwner(this).lookup("ability:" + type);
+      const ability = getOwner(this).lookup(`ability:${type}`);
 
-      Ember.assert("No ability class found for " + type, ability);
+      Ember.assert(`No ability class found for ${type}`, ability);
 
       const resource = get(this, resourceName);
-      set(ability, "model", resource);
+      set(ability, 'model', resource);
       return ability;
     });
   }

--- a/addon/helpers/can.js
+++ b/addon/helpers/can.js
@@ -1,28 +1,27 @@
 import Ember from 'ember';
 
 export default Ember.Helper.extend({
-  can: Ember.inject.service("can"),
+  can: Ember.inject.service(),
 
   compute([name, resource], hash) {
-    const service = this.get("can");
+    const service = this.get('can');
     const ability = service.build(name, resource, hash);
-
     const { propertyName } = service.parse(name);
 
     if (this._ability) {
-      this._ability.removeObserver(this._abilityProp, this, "recompute");
+      this._ability.removeObserver(this._abilityProp, this, 'recompute');
     }
 
     this._ability     = ability;
     this._abilityProp = propertyName;
 
-    ability.addObserver(propertyName, this, "recompute");
+    ability.addObserver(propertyName, this, 'recompute');
 
     return ability.get(propertyName);
   },
 
   destroy() {
-    this._ability.removeObserver(this._abilityProp, this, "recompute");
+    this._ability.removeObserver(this._abilityProp, this, 'recompute');
     return this._super();
   }
 });

--- a/addon/helpers/cannot.js
+++ b/addon/helpers/cannot.js
@@ -1,8 +1,9 @@
 import Ember from 'ember';
+import getOwner from 'ember-getowner-polyfill';
 
 export default Ember.Helper.extend({
   helper: Ember.computed(function() {
-    return Ember.getOwner(this).lookup('helper:can');
+    return getOwner(this).lookup('helper:can');
   }),
 
   compute(params, hash) {

--- a/addon/services/can.js
+++ b/addon/services/can.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import getOwner from 'ember-getowner-polyfill';
 import { normalizeCombined } from '../utils/normalize';
 
 export default Ember.Service.extend({
@@ -8,9 +9,9 @@ export default Ember.Service.extend({
 
   build(abilityString, resource, properties) {
     const names   = this.parse(abilityString);
-    const ability = Ember.getOwner(this).lookup("ability:" + names.abilityName);
+    const ability = getOwner(this).lookup(`ability:${names.abilityName}`);
 
-    Ember.assert("No ability type found for " + names.abilityName, ability);
+    Ember.assert(`No ability type found for ${names.abilityName}`, ability);
 
     // see if we've been given properties instead of resource
     if (!properties && resource && !(resource instanceof Ember.Object)) {

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,5 +1,6 @@
 /*jshint node:true*/
 module.exports = {
+  useVersionCompatibility: true,
   scenarios: [
     {
       name: 'default',
@@ -15,28 +16,6 @@ module.exports = {
         },
         resolutions: {
           'ember': 'release'
-        }
-      }
-    },
-    {
-      name: 'ember-beta',
-      bower: {
-        dependencies: {
-          'ember': 'components/ember#beta'
-        },
-        resolutions: {
-          'ember': 'beta'
-        }
-      }
-    },
-    {
-      name: 'ember-canary',
-      bower: {
-        dependencies: {
-          'ember': 'components/ember#canary'
-        },
-        resolutions: {
-          'ember': 'canary'
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -37,8 +37,9 @@
     "ember-cli-uglify": "^1.2.0",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.4",
+    "ember-getowner-polyfill": "1.0.0",
     "ember-disable-prototype-extensions": "^1.1.0",
-    "ember-try": "^0.1.2",
+    "ember-try": "^0.2.2",
     "ember-resolver": "^2.0.3",
     "ember-load-initializers": "^0.5.0",
     "loader.js": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "start": "ember server",
     "build": "ember build",
-    "test": "ember try:testall"
+    "test": "ember try:each"
   },
   "repository": {
     "type": "git",
@@ -56,7 +56,10 @@
     "ember-cli-babel": "^5.1.5"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "versionCompatibility": {
+      "ember": ">=1.13"
+    }
   },
   "bugs": {
     "url": "https://github.com/minutebase/ember-can/issues"


### PR DESCRIPTION
To support ember < 2.3.0 projects, we should rely on getOwner polyfill