### PR TITLE
Fix cannot recompute & destroy

### DIFF
--- a/addon/helpers/cannot.js
+++ b/addon/helpers/cannot.js
@@ -2,11 +2,18 @@ import Ember from 'ember';
 import getOwner from 'ember-getowner-polyfill';
 
 export default Ember.Helper.extend({
+  can: Ember.inject.service(),
+
   helper: Ember.computed(function() {
     return getOwner(this).lookup('helper:can');
   }),
 
   compute(params, hash) {
-    return !this.get('helper').compute(params, hash);
+    return !this.get('helper').compute.call(this, params, hash);
+  },
+
+  destroy() {
+    this.get('helper').destroy.call(this);
+    return this._super();
   }
 });


### PR DESCRIPTION
Fix a bug with ember-can `cannot` helper. 
The cannot helper used the instance created by the container when using `lookup`, which prevented it from correctly recompute.

I think the original intent was to use the compute method from the `can` helper. This commit does just that but still retrieve the `can` compute through the container. 

It may be a better idea to just statically import the can helper / or the compute method to avoid the creation of 2 helper instance each time cannot is used.
