### PR TITLE
fix ember-getowner-polyfill deprication

### DIFF
--- a/addon/computed.js
+++ b/addon/computed.js
@@ -1,7 +1,6 @@
 import Ember from 'ember';
-import getOwner from 'ember-getowner-polyfill';
 
-const { get, set } = Ember;
+const { get, set, getOwner } = Ember;
 
 export default {
   ability: function(type, resourceName) {

--- a/addon/helpers/cannot.js
+++ b/addon/helpers/cannot.js
@@ -1,8 +1,9 @@
 import Ember from 'ember';
-import getOwner from 'ember-getowner-polyfill';
+
+const { computed, getOwner } = Ember;
 
 export default Ember.Helper.extend({
-  helper: Ember.computed(function() {
+  helper: computed(function() {
     return getOwner(this).lookup('helper:can');
   }),
 

--- a/addon/services/can.js
+++ b/addon/services/can.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
-import getOwner from 'ember-getowner-polyfill';
 import { normalizeCombined } from '../utils/normalize';
+
+const { getOwner } = Ember;
 
 export default Ember.Service.extend({
   parse(name) {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "ember-cli-uglify": "^1.2.0",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.4",
-    "ember-getowner-polyfill": "1.0.0",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-try": "^0.2.2",
     "ember-resolver": "^2.0.3",


### PR DESCRIPTION
Fix for deprecation: 
```
ember-getowner-polyfill is now a true polyfill. Use Ember.getOwner directly instead of importing from ember-getowner-polyfill [deprecation id: ember-getowner-polyfill.import]
```