### PR TITLE
fix getOwner polyfill deprecation

### DIFF
--- a/addon/computed.js
+++ b/addon/computed.js
@@ -1,7 +1,6 @@
 import Ember from 'ember';
-import getOwner from 'ember-getowner-polyfill';
 
-const { get, set } = Ember;
+const { get, getOwner, set } = Ember;
 
 export default {
   ability: function(type, resourceName) {

--- a/addon/helpers/cannot.js
+++ b/addon/helpers/cannot.js
@@ -1,5 +1,8 @@
 import Ember from 'ember';
-import getOwner from 'ember-getowner-polyfill';
+
+const {
+  getOwner
+} = Ember;
 
 export default Ember.Helper.extend({
   helper: Ember.computed(function() {

--- a/addon/services/can.js
+++ b/addon/services/can.js
@@ -1,6 +1,10 @@
 import Ember from 'ember';
-import getOwner from 'ember-getowner-polyfill';
+
 import { normalizeCombined } from '../utils/normalize';
+
+const {
+  getOwner
+} = Ember;
 
 export default Ember.Service.extend({
   parse(name) {


### PR DESCRIPTION
A fix of the following deprecation:

`DEPRECATION: ember-getowner-polyfill is now a true polyfill. Use Ember.getOwner directly instead of importing from ember-getowner-polyfill [deprecation id: ember-getowner-polyfill.import]
        at logDeprecationStackTrace (http://localhost:4200/assets/vendor.js:22615:19)
        at HANDLERS.(anonymous function) (http://localhost:4200/assets/vendor.js:22725:7)
        at raiseOnDeprecation (http://localhost:4200/assets/vendor.js:22645:12)
        at HANDLERS.(anonymous function) (http://localhost:4200/assets/vendor.js:22725:7)
        at invoke (http://localhost:4200/assets/vendor.js:22741:7)
        at deprecate (http://localhost:4200/assets/vendor.js:22709:32)
        at Object.deprecate (http://localhost:4200/assets/vendor.js:34916:37)
        at Module.callback (http://localhost:4200/assets/vendor.js:192298:21)
        at Module.exports (http://localhost:4200/assets/vendor.js:140:32)`

The fix inspired by other addons, for instance:
[ember-simple-auth](https://github.com/simplabs/ember-simple-auth/pull/1124/commits/8c4b7633781d21596cb870d04688d1e97cac4a49)