### PR TITLE
Fix helper lookup on Ember 2.10+

### DIFF
--- a/addon/helpers/cannot.js
+++ b/addon/helpers/cannot.js
@@ -1,10 +1,12 @@
 import Ember from 'ember';
 
-const { getOwner } = Ember;
+const { getOwner, typeOf } = Ember;
 
 export default Ember.Helper.extend({
   helper: Ember.computed(function() {
-    return getOwner(this).lookup('helper:can');
+    var helper = getOwner(this).lookup('helper:can');
+
+    return typeOf(helper) === 'instance' ? helper : helper.create();
   }),
 
   compute(params, hash) {


### PR DESCRIPTION
The change here is backwards-compatible with Ember 2.3 etc. Fixes #50.

I did also run `ember init` with Ember 2.11 [here](https://github.com/Dockbit/ember-can/tree/ember-2.11), so let me know if you'd prefer to incorporate those changes instead. The fix applied here is also applied on that branch, but that branch breaks backwards-compatibility in its current state.
