### PR TITLE
Avoid errors when being transpiled by Babel 6.

### DIFF
--- a/app/initializers/setup-ember-can.js
+++ b/app/initializers/setup-ember-can.js
@@ -1,5 +1,5 @@
-/* globals requirejs, require */
-
+/* globals requirejs */
+import require from 'require';
 var Resolver;
 
 // This is a bit of a hack, but there is no way to detect


### PR DESCRIPTION
ember-cli 2.13 ships with Babel 6 transpilation for the host app itself. 

Unfortunately, Babel 6 has an issue with "bare require" statements like this. Adding the import fixes it (the module is actually provided by loader.js).