### PR TITLE
fix missed import change in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ We define an ability for the `Post` model in `/app/abilities/post.js`:
 ```js
 // app/abilities/post.js
 
-import { computed } from '@ember/object';
+import { reads } from '@ember/object/computed';
 import { Ability } from 'ember-can';
 
 export default Ability.extend({


### PR DESCRIPTION
I had never used the `reads` computed property before, so I was not sure at first if it was from Ember-Can or Ember. I thought you might like to have this updated.