### PR TITLE
Fix dependency version range

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
     }
   },
   "dependencies": {
-    "ember-cli-babel": "7.13.2",
-    "ember-inflector": "3.0.1"
+    "ember-cli-babel": "^7.13.2",
+    "ember-inflector": "^3.0.1"
   },
   "devDependencies": {
     "@ember/optional-features": "0.7.0",


### PR DESCRIPTION
Fixed version range is unnecessary in this case and will cause troubles to consumers.