### PR TITLE
fix(helper): check if helper is destroyed before adding the observer

### DIFF
--- a/addon/helpers/can.js
+++ b/addon/helpers/can.js
@@ -27,8 +27,10 @@ export default Helper.extend({
   },
 
   _addAbilityObserver(ability, propertyName) {
-    setProperties(this, { ability, propertyName });
-    addObserver(this, `ability.${propertyName}`, this, 'recompute');
+    if (!this.isDestroyed && !this.isDestroying) {
+      setProperties(this, { ability, propertyName });
+      addObserver(this, `ability.${propertyName}`, this, 'recompute');
+    }
   },
 
   _removeAbilityObserver() {


### PR DESCRIPTION
This prevents an error that was thrown when the helper is being destroyed while recomputing