### PR TITLE
use `get` from `@ember/object` to look up `propertyName` on `ability`…

### DIFF
--- a/addon/helpers/can.js
+++ b/addon/helpers/can.js
@@ -1,7 +1,7 @@
 import Helper from '@ember/component/helper';
 import { inject as service } from '@ember/service';
 import { addObserver, removeObserver } from '@ember/object/observers';
-import { setProperties } from '@ember/object';
+import { setProperties, get } from '@ember/object';
 
 export default Helper.extend({
   can: service(),
@@ -18,7 +18,7 @@ export default Helper.extend({
     this._removeAbilityObserver();
     this._addAbilityObserver(ability, propertyName);
 
-    return ability[propertyName];
+    return get(ability, propertyName);
   },
 
   destroy() {


### PR DESCRIPTION
This PR implements the solution proposed to fix issue https://github.com/minutebase/ember-can/issues/126.

We are in the process of upgraded dependencies and since we also use the `unknownProperty` method, we ran into the issue of having to use `.get` to retrieve our property.