### PR TITLE
Support methods in abilities

### DIFF
--- a/addon/ability.js
+++ b/addon/ability.js
@@ -1,7 +1,8 @@
 import EmberObject from '@ember/object';
 import { camelize } from '@ember/string';
+import { get } from '@ember/object';
 
-export default class Ability extends EmberObject {
+export default class EmberObjectAbility extends EmberObject {
   /**
    * Parse propertyName into ability property
    * eg: `createProject` will be parsed to `canCreateProject` using default definition
@@ -18,10 +19,17 @@ export default class Ability extends EmberObject {
    * eg: `createProject` will return a value for `canCreateProject`
    * using default `parseProperty` definition
    * @param  {String} propertyName property name, eg. `createProject`
+   * @param  {any} model
+   * @param  {Object} properties
    * @return {*}                   value of parsed `propertyName` property
    */
-  getAbility(propertyName) {
-    // eslint-disable-next-line ember/classic-decorator-no-classic-methods
-    return this.get(this.parseProperty(propertyName));
+  getAbility(propertyName, model, properties) {
+    const abilityValue = get(this, this.parseProperty(propertyName));
+
+    if (typeof abilityValue === 'function') {
+      return abilityValue.call(this, model, properties);
+    }
+
+    return abilityValue;
   }
 }

--- a/addon/helpers/can.js
+++ b/addon/helpers/can.js
@@ -1,41 +1,10 @@
 import Helper from '@ember/component/helper';
 import { inject as service } from '@ember/service';
-import { addObserver, removeObserver } from '@ember/object/observers';
-import { setProperties, get } from '@ember/object';
 
 export default class CanHelper extends Helper {
   @service('abilities') abilities;
 
-  ability;
-  propertyName;
-
-  compute([abilityString, model], properties) {
-    let { abilityName, propertyName } = this.abilities.parse(abilityString);
-    let ability = this.abilities.abilityFor(abilityName, model, properties);
-
-    propertyName = ability.parseProperty(propertyName);
-
-    this._removeAbilityObserver();
-    this._addAbilityObserver(ability, propertyName);
-
-    return get(ability, propertyName);
-  }
-
-  // eslint-disable-next-line ember/classic-decorator-hooks
-  destroy() {
-    this._removeAbilityObserver();
-    return super.destroy(...arguments);
-  }
-
-  _addAbilityObserver(ability, propertyName) {
-    setProperties(this, { ability, propertyName });
-    // eslint-disable-next-line ember/no-observers
-    addObserver(this, `ability.${propertyName}`, this, 'recompute');
-  }
-
-  _removeAbilityObserver() {
-    removeObserver(this, `ability.${this.propertyName}`, this, 'recompute');
-    this.ability && this.ability.destroy();
-    setProperties(this, { ability: null, propertyName: null });
+  compute([abilityString, model], properties = {}) {
+    return this.abilities.can(abilityString, model, properties);
   }
 }

--- a/addon/helpers/cannot.js
+++ b/addon/helpers/cannot.js
@@ -1,7 +1,10 @@
-import CanHelper from 'ember-can/helpers/can';
+import Helper from '@ember/component/helper';
+import { inject as service } from '@ember/service';
 
-export default class CannotHelper extends CanHelper {
-  compute() {
-    return !super.compute(...arguments);
+export default class CannotHelper extends Helper {
+  @service('abilities') abilities;
+
+  compute([abilityString, model], properties = {}) {
+    return this.abilities.cannot(abilityString, model, properties);
   }
 }

--- a/addon/services/abilities.js
+++ b/addon/services/abilities.js
@@ -54,7 +54,7 @@ export default class AbilitiesService extends Service {
    */
   valueFor(propertyName, abilityName, model, properties) {
     let ability = this.abilityFor(abilityName, model, properties);
-    let result = ability.getAbility(propertyName);
+    let result = ability.getAbility(propertyName, model, properties);
 
     ability.destroy();
 

--- a/tests/addon/ability-test.js
+++ b/tests/addon/ability-test.js
@@ -1,4 +1,4 @@
-import { test, skip, module } from 'qunit';
+import { test, module } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import Ability from 'ember-can/ability';
 import Sinon from 'sinon';
@@ -39,7 +39,7 @@ module('Addon | ability', function (hooks) {
       assert.strictEqual(ability.getAbility('writeComment'), undefined);
     });
 
-    skip('supports methods', function (assert) {
+    test('supports methods', function (assert) {
       class MyAbility extends Ability {
         canWritePost() {
           return true;
@@ -52,7 +52,7 @@ module('Addon | ability', function (hooks) {
       assert.strictEqual(ability.getAbility('writeComment'), undefined);
     });
 
-    skip('supports models and properties', function (assert) {
+    test('supports models and properties', function (assert) {
       class MyAbility extends Ability {
         canWritePost() {
           return true;

--- a/tests/addon/helpers/cannot-test.js
+++ b/tests/addon/helpers/cannot-test.js
@@ -7,10 +7,38 @@ import Service from '@ember/service';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 // eslint-disable-next-line ember/no-computed-properties-in-native-classes
-import { computed } from '@ember/object';
+import { computed, set } from '@ember/object';
+import Sinon from 'sinon';
 
-module('Addon | Helper | can', function (hooks) {
+module('Addon | Helper | cannot', function (hooks) {
   setupRenderingTest(hooks);
+
+  test('it is calling service correctly', async function (assert) {
+    assert.expect(4);
+
+    this.owner.register(
+      'ability:post',
+      class extends Ability {
+        get canWrite() {
+          return this.model?.write;
+        }
+      }
+    );
+    const service = this.owner.lookup('service:abilities');
+
+    const spy = Sinon.spy(service, 'cannot');
+
+    this.model = { name: 'can' };
+
+    await render(
+      hbs`{{if (cannot "write post" this.model prop="name") "false" "true"}}`
+    );
+
+    assert.true(spy.calledOnce);
+    assert.strictEqual(spy.firstCall.args[0], 'write post');
+    assert.strictEqual(spy.firstCall.args[1], this.model);
+    assert.deepEqual(spy.firstCall.args[2], { prop: 'name' });
+  });
 
   test('it reacts to model change', async function (assert) {
     assert.expect(4);
@@ -31,14 +59,16 @@ module('Addon | Helper | can', function (hooks) {
     await render(hbs`{{if (cannot "write post" this.model) "false" "true"}}`);
     assert.dom(this.element).hasText('false');
 
-    this.set('model', new Model());
+    set(this, 'model', new Model());
+    await settled();
     assert.dom(this.element).hasText('true');
 
     this.model.write = false;
     await settled();
     assert.dom(this.element).hasText('false');
 
-    this.set('model', new Model());
+    set(this, 'model', new Model());
+    await settled();
     assert.dom(this.element).hasText('true');
   });
 
@@ -142,8 +172,56 @@ module('Addon | Helper | can', function (hooks) {
     await render(hbs`{{if (cannot "write post") "false" "true"}}`);
     assert.dom(this.element).hasText('false');
 
-    session.set('isChange', true);
+    set(session, 'isChange', true);
 
+    await settled();
+
+    assert.dom(this.element).hasText('true');
+  });
+
+  test('it reacts to changes when using methods', async function (assert) {
+    assert.expect(3);
+
+    this.owner.register(
+      'service:session',
+      class extends Service {
+        @tracked isTrackedChanged = false;
+        isComputedChanged = false;
+
+        get isTracked() {
+          return this.isTrackedChanged;
+        }
+
+        @computed('isComputedChanged')
+        get isComputed() {
+          return this.isComputedChanged;
+        }
+      }
+    );
+
+    this.owner.register(
+      'ability:post',
+      class extends Ability {
+        @service session;
+
+        canWrite() {
+          return this.session.isTracked && this.session.isComputed;
+        }
+      }
+    );
+
+    const session = this.owner.lookup('service:session');
+
+    await render(hbs`{{if (cannot "write post") "false" "true"}}`);
+    assert.dom(this.element).hasText('false');
+
+    session.isTrackedChanged = true;
+
+    await settled();
+
+    assert.dom(this.element).hasText('false');
+
+    set(session, 'isComputedChanged', true);
     await settled();
 
     assert.dom(this.element).hasText('true');

--- a/tests/addon/services/abilities-test.js
+++ b/tests/addon/services/abilities-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { Ability } from 'ember-can';
+import Sinon from 'sinon';
 
 module('Unit | Service | abilities', function (hooks) {
   setupTest(hooks);
@@ -40,23 +41,34 @@ module('Unit | Service | abilities', function (hooks) {
   });
 
   test('valueFor', function (assert) {
-    assert.expect(1);
+    assert.expect(4);
 
-    let service = this.owner.lookup('service:abilities');
+    const fakeAbility = Sinon.fake(({ yeah }) => yeah);
 
     this.owner.register(
       'ability:super-model',
       class extends Ability {
-        get canTouchThis() {
-          return this.model.yeah;
+        canTouchThis() {
+          return fakeAbility(...arguments);
         }
       }
     );
 
+    let service = this.owner.lookup('service:abilities');
+
     assert.strictEqual(
-      service.valueFor('touchThis', 'superModel', { yeah: 'Yeah!' }),
+      service.valueFor(
+        'touchThis',
+        'superModel',
+        { yeah: 'Yeah!' },
+        { props: true }
+      ),
       'Yeah!'
     );
+
+    assert.true(fakeAbility.calledOnce);
+    assert.deepEqual(fakeAbility.firstCall.args[0], { yeah: 'Yeah!' });
+    assert.deepEqual(fakeAbility.firstCall.args[1], { props: true });
   });
 
   test('abilityFor', function (assert) {


### PR DESCRIPTION
This is a new feature that will allow to define methods as abilities checkers.
Example:

```js
      class extends Ability {
        canTouchThis(model, properties = {}) {
          return model.ok && properties.ok;
        }
      }

```

This will bring use one step closer to ES6 base-class and improving the performance by having abilities as singletons