### PR TITLE
Drop old test styles in blueprint (`ember-cli-mocha` & `ember-cli-qunit`)

### DIFF
--- a/ember-can/blueprints/ability-test/index.js
+++ b/ember-can/blueprints/ability-test/index.js
@@ -8,96 +8,33 @@ module.exports = {
 
   shouldTransformTypeScript: true,
 
-  _getTestStyle: function () {
-    if ('ember-cli-mocha' in this.project.addonPackages) {
-      return 'mocha';
-    } else if ('ember-cli-qunit' in this.project.addonPackages) {
-      return 'qunit';
-    }
-  },
-
   locals: function (options) {
     var name = options.entity.name;
 
-    var testStyle = this._getTestStyle();
-    if (!testStyle) {
-      this.ui.writeLine("Couldn't determine test style - using QUnit");
-      testStyle = 'qunit';
-    }
+    var imports =
+      "import { module, test } from 'qunit';" +
+      EOL +
+      "import { setupTest } from 'ember-qunit';";
 
-    var imports, test;
-    if (testStyle === 'qunit') {
-      imports =
-        "import { module, test } from 'qunit';" +
-        EOL +
-        "import { setupTest } from 'ember-qunit';";
-      test =
-        "module('Unit | Ability | " +
-        name +
-        "', function(hooks) {" +
-        EOL +
-        '  setupTest(hooks);' +
-        EOL +
-        EOL +
-        "  test('it exists', function(assert) {" +
-        EOL +
-        "    const ability = this.owner.lookup('ability:" +
-        name +
-        "');" +
-        EOL +
-        '    assert.ok(ability);' +
-        EOL +
-        '  });' +
-        EOL +
-        '});';
-    } else if (testStyle === 'mocha') {
-      imports =
-        '/* jshint expr:true */' +
-        EOL +
-        "import { expect } from 'chai';" +
-        EOL +
-        'import {' +
-        EOL +
-        '  describeModule,' +
-        EOL +
-        '  it' +
-        EOL +
-        "} from 'ember-mocha';";
-      test =
-        'describeModule(' +
-        EOL +
-        "  'ability:" +
-        name +
-        "'," +
-        EOL +
-        "  '" +
-        name +
-        " Ability'," +
-        EOL +
-        '  {' +
-        EOL +
-        '    // Specify the other units that are required for this test.' +
-        EOL +
-        "    // needs: ['service:foo']" +
-        EOL +
-        '  },' +
-        EOL +
-        '  function() {' +
-        EOL +
-        '    // Replace this with your real tests.' +
-        EOL +
-        "    it('exists', function() {" +
-        EOL +
-        '      const ability = this.subject();' +
-        EOL +
-        '      expect(ability).to.be.ok;' +
-        EOL +
-        '    });' +
-        EOL +
-        '  }' +
-        EOL +
-        ');';
-    }
+    var test =
+      "module('Unit | Ability | " +
+      name +
+      "', function(hooks) {" +
+      EOL +
+      '  setupTest(hooks);' +
+      EOL +
+      EOL +
+      "  test('it exists', function(assert) {" +
+      EOL +
+      "    const ability = this.owner.lookup('ability:" +
+      name +
+      "');" +
+      EOL +
+      '    assert.ok(ability);' +
+      EOL +
+      '  });' +
+      EOL +
+      '});';
 
     return {
       imports: imports,


### PR DESCRIPTION
The current test blueprints are supporting different test styles depending which package is installed.

### Why dropping `ember-cli-mocha`?
`ember-cli-mocha` was deprecated in year 2019 and replaced with `ember-mocha`, so we can drop this test style.
`ember-mocha` is since v5.0 also depreacted [see RFC](https://rfcs.emberjs.com/id/0858-deprecate-ember-mocha/), for this reason we don't need to add.

### Why dropping `ember-cli-qunit`?
`ember-cli-qunit` was deprecated in year 2019 and replaced with `ember-qunit`. The codepart has already added as import `ember-qunit`.

### Conclusion
In next version we support only `ember-qunit` as test library in blueprint