### PR TITLE
Drop ember versions < 3.28

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,6 @@ jobs:
       fail-fast: false
       matrix:
         try-scenario:
-          - ember-lts-3.20
-          - ember-lts-3.24
           - ember-lts-3.28
           - ember-lts-4.4
           - ember-lts-4.8

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ ember install ember-can
 
 ## Compatibility
 
-* Ember.js v3.20 or above
+* Ember.js v3.28 or above
 * Embroider or ember-auto-import v2
 
 ## Quick Example

--- a/test-app/config/ember-try.js
+++ b/test-app/config/ember-try.js
@@ -8,30 +8,6 @@ module.exports = async function () {
     usePnpm: true,
     scenarios: [
       {
-        name: 'ember-lts-3.20',
-        npm: {
-          devDependencies: {
-            '@ember/test-helpers': '^2.9.4',
-            'ember-cli': '~4.12.2',
-            'ember-qunit': '^5.1.5',
-            'ember-resolver': '^8.0.0',
-            'ember-source': '~3.20.5',
-          },
-        },
-      },
-      {
-        name: 'ember-lts-3.24',
-        npm: {
-          devDependencies: {
-            '@ember/test-helpers': '^2.9.4',
-            'ember-cli': '~4.12.2',
-            'ember-qunit': '^5.1.5',
-            'ember-resolver': '^8.0.0',
-            'ember-source': '~3.24.3',
-          },
-        },
-      },
-      {
         name: 'ember-lts-3.28',
         npm: {
           devDependencies: {


### PR DESCRIPTION
To reduce maintenance (maybe also possible bug reportings) for old ember version, we should drop ember version < `3.28`.

- ember `v3.20` was has got his last patch `September 15, 2021`
- ember `v3.24` has got his last patch `March 10, 2022`

This means, that we support apps with `v3.28`+ (last patch `January 2, 2023`)

I think, peoples which are still on this old version, can use ´v4` like before (without getting new features).

Its possible that consumer apps with ember < `v3.28` can also use next major version, without any issues, but its there own risk.