### PR TITLE
fix: make helpers lowercase in template registry

### DIFF
--- a/ember-can/src/template-registry.ts
+++ b/ember-can/src/template-registry.ts
@@ -2,6 +2,6 @@
 import CannotHelper from './helpers/cannot.ts';
 
 export default interface Registry {
-  Can: typeof CanHelper;
-  Cannot: typeof CannotHelper;
+  can: typeof CanHelper;
+  cannot: typeof CannotHelper;
 }


### PR DESCRIPTION
![image](https://github.com/minutebase/ember-can/assets/2275005/2d35f338-f592-4b09-a372-634e17f34bf1)
