### PR TITLE
Addon v2 should always use relative paths for own files

### DIFF
--- a/ember-can/src/helpers/can.ts
+++ b/ember-can/src/helpers/can.ts
@@ -1,6 +1,6 @@
 import Helper from '@ember/component/helper';
 import { inject as service } from '@ember/service';
-import type Ability from 'ember-can/services/abilities';
+import type Ability from '../services/abilities.ts';
 
 interface CanSignature {
   Args: {

--- a/ember-can/src/helpers/cannot.ts
+++ b/ember-can/src/helpers/cannot.ts
@@ -1,6 +1,6 @@
 import Helper from '@ember/component/helper';
 import { inject as service } from '@ember/service';
-import type Ability from 'ember-can/services/abilities';
+import type Ability from '../services/abilities.ts';
 
 interface CannotSignature {
   Args: {

--- a/ember-can/src/index.ts
+++ b/ember-can/src/index.ts
@@ -1,3 +1,3 @@
-import Ability from 'ember-can/ability';
+import Ability from './ability.ts';
 
 export { Ability };

--- a/ember-can/src/services/abilities.ts
+++ b/ember-can/src/services/abilities.ts
@@ -1,5 +1,5 @@
 import Service from '@ember/service';
-import Ability from 'ember-can/ability';
+import Ability from '../ability.ts';
 import { assert } from '@ember/debug';
 import { getOwner } from '@ember/application';
 import normalizeAbilityString from '../-private/normalize.ts';

--- a/ember-can/src/template-registry.ts
+++ b/ember-can/src/template-registry.ts
@@ -1,5 +1,5 @@
-﻿import CanHelper from 'ember-can/helpers/can';
-import CannotHelper from 'ember-can/helpers/cannot';
+﻿import CanHelper from './helpers/can.ts';
+import CannotHelper from './helpers/cannot.ts';
 
 export default interface Registry {
   can: typeof CanHelper;


### PR DESCRIPTION
As defined in RFC of V2 addons, we should always use relative urls inside addon for own scripts

https://rfcs.emberjs.com/id/0507-embroider-v2-package-format/
> Own Javascript: Imports
Modules in Own Javascript are allowed to use ECMA static import and dynamic import() to resolve any allowed dependency, causing it to be included in the build whenever the importing module is included. This replaces app.import. Resolution follows prevailing Node rules. (This usually means the node_modules algorithm, but it could also mean Yarn PnP. The difference shouldn't matter if you are correctly declaring all your allowed dependencies.)
Notice that a package’s allowed dependencies do not include the package itself. This is consistent with how Node resolution works. To import files from within your own package you must use relative paths. This is different from how run-time AMD module resolution has historically worked in Ember Apps. (@embroider/compat implements automatic adjustment for this case when compiling from v1 to v2).

reverts #178