### PR TITLE
Fix ability test blueprint formatting

### DIFF
--- a/ember-can/blueprints/ability-test/index.js
+++ b/ember-can/blueprints/ability-test/index.js
@@ -19,12 +19,12 @@ module.exports = {
     var test =
       "module('Unit | Ability | " +
       name +
-      "', function(hooks) {" +
+      "', function (hooks) {" +
       EOL +
       '  setupTest(hooks);' +
       EOL +
       EOL +
-      "  test('it exists', function(assert) {" +
+      "  test('it exists', function (assert) {" +
       EOL +
       "    const ability = this.owner.lookup('ability:" +
       name +


### PR DESCRIPTION
Prettier requires spaces before function parameters. This PR adds those so formatting is not needed after generating an ability test.