### PR TITLE
Change Ember Object Reopen to using purely the initialize function

### DIFF
--- a/ember-can/src/initializers/setup-ember-can.js
+++ b/ember-can/src/initializers/setup-ember-can.js
@@ -1,14 +1,10 @@
-﻿import Resolver from 'ember-resolver';
-
-Resolver.reopen({
-  init() {
-    this._super();
-    this.pluralizedTypes = {
-      ...this.pluralizedTypes,
-      ability: 'abilities',
-    };
-  },
-});
-
-export function initialize() {}
+export function initialize(application) {
+  if (
+    application.__registry__ &&
+    application.__registry__.resolver &&
+    application.__registry__.resolver.pluralizedTypes
+  ) {
+    application.__registry__.resolver.pluralizedTypes['ability'] = 'abilities';
+  }
+}
 export default { initialize };


### PR DESCRIPTION
The most recent ember-resolver (v13) update has removed the use of ember objects in the resolver class. So reopen no longer works. This pulse attempts to fix it