### PR TITLE
Widen `ember-inflector` support

### DIFF
--- a/ember-can/package.json
+++ b/ember-can/package.json
@@ -126,7 +126,7 @@
   },
   "peerDependencies": {
     "@ember/string": "^3.1.1 || ^4.0.0",
-    "ember-inflector": "^4.0.2 || ^5.0.1",
+    "ember-inflector": "^4.0.2 || >=5.0.1",
     "ember-source": "^3.28.0 || ^4.0.0 || >=5.0.0",
     "ember-resolver": ">= 8.0.0"
   }


### PR DESCRIPTION
Some days ago there was release `ember-inflector` v6 https://github.com/emberjs/ember-inflector/releases/tag/v6.0.0-ember-inflector.
We should whitelist current and future `ember-inflector` versions, to reduce maintaince costs