### PR TITLE
Cleanup `@ember/service` deprecation

### DIFF
--- a/ember-can/src/-private/resolver.ts
+++ b/ember-can/src/-private/resolver.ts
@@ -5,7 +5,6 @@ export default function extendResolver(
 ): typeof Resolver {
   return class EmberCanResolver extends resolver {
     pluralizedTypes: Record<string, string> = {
-      // @ts-expect-error Property 'pluralizedTypes' is used before its initialization.
       ...this.pluralizedTypes,
       ability: 'abilities',
     };

--- a/ember-can/src/-private/resolver.ts
+++ b/ember-can/src/-private/resolver.ts
@@ -5,7 +5,8 @@ export default function extendResolver(
 ): typeof Resolver {
   return class EmberCanResolver extends resolver {
     pluralizedTypes: Record<string, string> = {
-      ...super.pluralizedTypes,
+      // @ts-expect-error Property 'pluralizedTypes' is used before its initialization.
+      ...this.pluralizedTypes,
       ability: 'abilities',
     };
   };

--- a/ember-can/src/-private/resolver.ts
+++ b/ember-can/src/-private/resolver.ts
@@ -5,7 +5,7 @@ export default function extendResolver(
 ): typeof Resolver {
   return class EmberCanResolver extends resolver {
     pluralizedTypes: Record<string, string> = {
-      ...this.pluralizedTypes,
+      ...super.pluralizedTypes,
       ability: 'abilities',
     };
   };

--- a/ember-can/src/helpers/can.ts
+++ b/ember-can/src/helpers/can.ts
@@ -1,6 +1,8 @@
 import Helper from '@ember/component/helper';
-import { inject as service } from '@ember/service';
+import * as s from '@ember/service';
 import type Ability from '../services/abilities.ts';
+
+const service = s.service ?? s.inject;
 
 interface CanSignature {
   Args: {

--- a/ember-can/src/helpers/cannot.ts
+++ b/ember-can/src/helpers/cannot.ts
@@ -1,6 +1,8 @@
 import Helper from '@ember/component/helper';
-import { inject as service } from '@ember/service';
+import * as s from '@ember/service';
 import type Ability from '../services/abilities.ts';
+
+const service = s.service ?? s.inject;
 
 interface CannotSignature {
   Args: {


### PR DESCRIPTION
In ember v6.3 there was added deprecation for service import from inject https://deprecations.emberjs.com/id/importing-inject-from-ember-service/

This changes allows us to hold support for `ember-source` <= 4.0 ([see changelog](https://github.com/emberjs/ember.js/blob/main/CHANGELOG.md#v410-december-28-2021)) and removes deprecation in newer versions