### PR TITLE
Remove support for ember < 4.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,9 +62,6 @@ jobs:
       fail-fast: false
       matrix:
         try-scenario:
-          - ember-lts-3.28
-          - ember-lts-4.4
-          - ember-lts-4.8
           - ember-lts-4.12
           - ember-lts-5.4
           - ember-lts-5.8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,9 @@ jobs:
           - ember-lts-4.12
           - ember-lts-5.4
           - ember-lts-5.8
+          - ember-resolver-10
+          - ember-resolver-11
+          - ember-resolver-12
           - ember-release
           - ember-beta
           - ember-canary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,6 @@ jobs:
           - ember-lts-4.12
           - ember-lts-5.4
           - ember-lts-5.8
-          - ember-resolver-12
           - ember-release
           - ember-beta
           - ember-canary

--- a/ember-can/package.json
+++ b/ember-can/package.json
@@ -125,9 +125,9 @@
     }
   },
   "peerDependencies": {
-    "@ember/string": "^3.1.1 || ^4.0.0",
-    "ember-inflector": "^4.0.2 || >=5.0.1",
+    "@ember/string": ">=3.0.1",
+    "ember-inflector": ">=5.0.1",
     "ember-source": ">=4.12.0",
-    "ember-resolver": ">= 8.0.0"
+    "ember-resolver": ">= 10.0.0"
   }
 }

--- a/ember-can/package.json
+++ b/ember-can/package.json
@@ -127,7 +127,7 @@
   "peerDependencies": {
     "@ember/string": "^3.1.1 || ^4.0.0",
     "ember-inflector": "^4.0.2 || >=5.0.1",
-    "ember-source": "^4.12.0 || >=5.0.0",
+    "ember-source": ">=4.12.0",
     "ember-resolver": ">= 8.0.0"
   }
 }

--- a/ember-can/package.json
+++ b/ember-can/package.json
@@ -125,9 +125,9 @@
     }
   },
   "peerDependencies": {
-    "@ember/string": "^4.0.0",
-    "ember-inflector": ">=5.0.1",
-    "ember-source": ">=4.12.0",
-    "ember-resolver": ">= 13.0.0"
+    "@ember/string": "^3.1.1 || ^4.0.0",
+    "ember-inflector": "^4.0.2 || >=5.0.1",
+    "ember-source": "^4.12.0 || >=5.0.0",
+    "ember-resolver": ">= 8.0.0"
   }
 }

--- a/ember-can/package.json
+++ b/ember-can/package.json
@@ -127,7 +127,7 @@
   "peerDependencies": {
     "@ember/string": "^4.0.0",
     "ember-inflector": ">=5.0.1",
-    "ember-source": "^4.12.0 || >=5.0.0",
+    "ember-source": ">=4.12.0",
     "ember-resolver": ">= 12.0.0"
   }
 }

--- a/ember-can/package.json
+++ b/ember-can/package.json
@@ -125,9 +125,9 @@
     }
   },
   "peerDependencies": {
-    "@ember/string": "^3.1.1 || ^4.0.0",
-    "ember-inflector": "^4.0.2 || >=5.0.1",
-    "ember-source": "^3.28.0 || ^4.0.0 || >=5.0.0",
-    "ember-resolver": ">= 8.0.0"
+    "@ember/string": "^4.0.0",
+    "ember-inflector": ">=5.0.1",
+    "ember-source": "^4.12.0 || >=5.0.0",
+    "ember-resolver": ">= 12.0.0"
   }
 }

--- a/ember-can/package.json
+++ b/ember-can/package.json
@@ -128,6 +128,6 @@
     "@ember/string": "^4.0.0",
     "ember-inflector": ">=5.0.1",
     "ember-source": ">=4.12.0",
-    "ember-resolver": ">= 12.0.0"
+    "ember-resolver": ">= 13.0.0"
   }
 }

--- a/ember-can/src/helpers/can.ts
+++ b/ember-can/src/helpers/can.ts
@@ -1,8 +1,6 @@
 import Helper from '@ember/component/helper';
-import * as s from '@ember/service';
+import { service } from '@ember/service';
 import type Ability from '../services/abilities.ts';
-
-const service = s.service ?? s.inject;
 
 interface CanSignature {
   Args: {

--- a/ember-can/src/helpers/cannot.ts
+++ b/ember-can/src/helpers/cannot.ts
@@ -1,8 +1,6 @@
 import Helper from '@ember/component/helper';
-import * as s from '@ember/service';
+import { service } from '@ember/service';
 import type Ability from '../services/abilities.ts';
-
-const service = s.service ?? s.inject;
 
 interface CannotSignature {
   Args: {

--- a/ember-can/src/services/abilities.ts
+++ b/ember-can/src/services/abilities.ts
@@ -1,7 +1,7 @@
 import Service from '@ember/service';
 import Ability from '../ability.ts';
 import { assert } from '@ember/debug';
-import { getOwner } from '@ember/application';
+import { getOwner } from '@ember/owner';
 import normalizeAbilityString from '../-private/normalize.ts';
 
 export default class AbilitiesService extends Service {

--- a/test-app/config/ember-try.js
+++ b/test-app/config/ember-try.js
@@ -8,36 +8,6 @@ module.exports = async function () {
     usePnpm: true,
     scenarios: [
       {
-        name: 'ember-lts-3.28',
-        npm: {
-          devDependencies: {
-            '@ember/test-helpers': '^2.9.4',
-            'ember-cli': '~4.12.2',
-            'ember-qunit': '^6.0.0',
-            'ember-resolver': '^8.0.0',
-            'ember-source': '~3.28.0',
-          },
-        },
-      },
-      {
-        name: 'ember-lts-4.4',
-        npm: {
-          devDependencies: {
-            'ember-resolver': '^8.0.0',
-            'ember-source': '~4.4.0',
-          },
-        },
-      },
-      {
-        name: 'ember-lts-4.8',
-        npm: {
-          devDependencies: {
-            'ember-resolver': '^11.0.0',
-            'ember-source': '~4.8.0',
-          },
-        },
-      },
-      {
         name: 'ember-lts-4.12',
         npm: {
           devDependencies: {

--- a/test-app/config/ember-try.js
+++ b/test-app/config/ember-try.js
@@ -35,6 +35,7 @@ module.exports = async function () {
         name: 'ember-resolver-10',
         npm: {
           devDependencies: {
+            '@ember/string': '^3.0.1',
             'ember-source': '~4.12.0',
             'ember-resolver': '^10.0.0',
           },

--- a/test-app/config/ember-try.js
+++ b/test-app/config/ember-try.js
@@ -32,6 +32,33 @@ module.exports = async function () {
         },
       },
       {
+        name: 'ember-resolver-10',
+        npm: {
+          devDependencies: {
+            'ember-source': '~4.12.0',
+            'ember-resolver': '^10.0.0',
+          },
+        },
+      },
+      {
+        name: 'ember-resolver-11',
+        npm: {
+          devDependencies: {
+            'ember-source': '~4.12.0',
+            'ember-resolver': '^11.0.0',
+          },
+        },
+      },
+      {
+        name: 'ember-resolver-12',
+        npm: {
+          devDependencies: {
+            'ember-source': '~5.8.0',
+            'ember-resolver': '^12.0.0',
+          },
+        },
+      },
+      {
         name: 'ember-release',
         npm: {
           devDependencies: {

--- a/test-app/config/ember-try.js
+++ b/test-app/config/ember-try.js
@@ -32,15 +32,6 @@ module.exports = async function () {
         },
       },
       {
-        name: 'ember-resolver-12',
-        npm: {
-          devDependencies: {
-            'ember-source': '~5.8.0',
-            'ember-resolver': '^12.0.0',
-          },
-        },
-      },
-      {
         name: 'ember-release',
         npm: {
           devDependencies: {


### PR DESCRIPTION
peerDepdencies support:
- we support all from ember-cli v4.12.x [see](https://github.com/ember-cli/ember-cli/blob/v4.12.3/blueprints/app/files/package.json)
- `ember-inflector` is not in ember-cli, so we do take 5x, because 6x is right now just 3 weeks old