### PR TITLE
Remove ember-source as a peer dependency

### DIFF
--- a/ember-can/package.json
+++ b/ember-can/package.json
@@ -88,7 +88,6 @@
   "peerDependencies": {
     "@ember/string": ">= 3.0.1",
     "ember-inflector": ">= 5.0.1",
-    "ember-source": ">= 4.12.0",
     "ember-resolver": ">= 10.0.0"
   },
   "ember": {


### PR DESCRIPTION
- ember-source: removed because the embroider / auto-import know what we intend - it's not bad to have if someone manages their dep graph correctly, which is easier with pnpm, but not everyone gets it right, and folks have a hard time tracking down errors
- @glimmer/tracking removed because it's a real package, but one we don't want to use. This comes up in embroider/vite where the presence of real packages always takes precedence over virtual packages. This is actually problematic because it can break reactivity in subtle ways, even if a dep graph is correct - allowing duplicates of dependencies, which for the glimmer internals, we don't want.

ref https://github.com/ember-cli/ember-addon-blueprint/pull/35