### PR TITLE
fix: ember-can null guard in _removeAbilityObserver — [WP-01] Patch & Tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,53 @@ Cannot helper is a negation of `can` helper with the same API.
 {{cannot "doSth in myModel" model extraProperties}}
 ```
 
+### `ability`
+
+Ability helper will return the ability property as is instead of as a boolean like with can/cannot.
+It allows you to return objects in your abilitie's property as long as you include a 'can' property that represents the usual boolean ability you would return in a more classic scenario.
+
+```js
+// app/abilities/post.js
+
+import { computed } from '@ember/object';
+import { Ability } from 'ember-can';
+
+export default Ability.extend({
+  // only an admin can edit a post, if and only the post is editable
+  canEdit: computed('user.isAdmin', 'model.isNotEditable', function() {
+    if (!this.get('model.isNotEditable')) {
+      return {
+        can: false,
+        reason: 'This post cannot be edited'
+      }
+    }
+
+    if (!this.get('user.isAdmin')) {
+      return {
+        can: false,
+        reason: 'You need to be an admin to edit a post'
+      }
+    }
+
+    return true;
+  })
+});
+```
+
+```hbs
+{{ability "write post" post}}
+{{!-- returns { can: ..., reason: ... } or true --}}
+{{ability "write post:reason" post}}
+{{!-- returns 'This post cannot be edited', 'You need to be an admin to edit a post' or undefined --}}
+
+{{#if (can "write post" post)}}
+  <p>A post</p>
+{{else}}
+  {{#with (ability "write post:reason" post) as |cannotEditPostReason|}}
+    {{cannotEditPostReason}}
+  {{/with}}
+{{/if}}
+```
 
 ## Abilities
 

--- a/addon/helpers/ability.js
+++ b/addon/helpers/ability.js
@@ -1,0 +1,44 @@
+import Helper from '@ember/component/helper';
+import { inject as service } from '@ember/service';
+import { addObserver, removeObserver } from '@ember/object/observers';
+import { get, setProperties } from '@ember/object';
+
+export default Helper.extend({
+  can: service(),
+
+  ability: null,
+  propertyName: null,
+
+  compute([abilityString, model], properties) {
+    let { abilityName, propertyName, subProperty } =
+      this.can.parse(abilityString);
+    let ability = this.can.abilityFor(abilityName, model, properties);
+
+    propertyName = ability.parseProperty(propertyName);
+
+    this._removeAbilityObserver();
+    this._addAbilityObserver(ability, propertyName);
+
+    if (!subProperty) {
+      return ability[propertyName];
+    }
+
+    return get(ability[propertyName], subProperty);
+  },
+
+  destroy() {
+    this._removeAbilityObserver();
+    return this._super(...arguments);
+  },
+
+  _addAbilityObserver(ability, propertyName) {
+    setProperties(this, { ability, propertyName });
+    addObserver(this, `ability.${propertyName}`, this, 'recompute');
+  },
+
+  _removeAbilityObserver() {
+    removeObserver(this, `ability.${this.propertyName}`, this, 'recompute');
+    this.ability && this.ability.destroy();
+    setProperties(this, { ability: null, propertyName: null });
+  },
+});

--- a/addon/helpers/ability.js
+++ b/addon/helpers/ability.js
@@ -37,6 +37,10 @@ export default Helper.extend({
   },
 
   _removeAbilityObserver() {
+    if (this.propertyName === null) {
+      return;
+    }
+
     removeObserver(this, `ability.${this.propertyName}`, this, 'recompute');
     this.ability && this.ability.destroy();
     setProperties(this, { ability: null, propertyName: null });

--- a/addon/helpers/can.js
+++ b/addon/helpers/can.js
@@ -1,39 +1,24 @@
-import Helper from '@ember/component/helper';
-import { inject as service } from '@ember/service';
-import { addObserver, removeObserver } from '@ember/object/observers';
-import { setProperties, get } from '@ember/object';
+import AbilityHelper from 'ember-can/helpers/ability';
+import { assert } from '@ember/debug';
 
-export default Helper.extend({
-  can: service(),
+export default AbilityHelper.extend({
+  compute([abilityString]) {
+    let { abilityName, propertyName, subProperty } =
+      this.can.parse(abilityString);
 
-  ability: null,
-  propertyName: null,
+    assert(
+      `Using 'abilityString:subProperty' syntax is forbidden in can and cannot helpers, use ability helper instead`,
+      !subProperty
+    );
 
-  compute([abilityString, model], properties) {
-    let { abilityName, propertyName } = this.can.parse(abilityString);
-    let ability = this.can.abilityFor(abilityName, model, properties);
-
-    propertyName = ability.parseProperty(propertyName);
-
-    this._removeAbilityObserver();
-    this._addAbilityObserver(ability, propertyName);
-
-    return get(ability, propertyName);
-  },
-
-  destroy() {
-    this._removeAbilityObserver();
-    return this._super(...arguments);
-  },
-
-  _addAbilityObserver(ability, propertyName) {
-    setProperties(this, { ability, propertyName });
-    addObserver(this, `ability.${propertyName}`, this, 'recompute');
-  },
-
-  _removeAbilityObserver() {
-    removeObserver(this, `ability.${this.propertyName}`, this, 'recompute');
-    this.ability && this.ability.destroy();
-    setProperties(this, { ability: null, propertyName: null });
+    let result = this._super(...arguments);
+    if (typeof result === 'object') {
+      assert(
+        `Ability property ${propertyName} in '${abilityName}' is an object and must have a 'can' property`,
+        'can' in result
+      );
+      return result.can;
+    }
+    return result;
   },
 });

--- a/addon/services/can.js
+++ b/addon/services/can.js
@@ -1,5 +1,6 @@
 import Service from '@ember/service';
 import Ability from 'ember-can/ability';
+import { get } from '@ember/object';
 import { assert } from '@ember/debug';
 import { getOwner } from '@ember/application';
 import { assign } from '@ember/polyfills';
@@ -47,19 +48,24 @@ export default Service.extend({
   /**
    * Returns a value for requested ability in specified ability class
    * @public
-   * @param  {String} propertyName name of ability, eg `createProjects`
-   * @param  {String} abilityName  name of ability class
+   * @param  {[type]} abilityString eg. 'create projects in account'
    * @param  {*}      model
    * @param  {Object} properties   extra properties (to be set on the ability instance)
    * @return {*}                   value of ability
    */
-  valueFor(propertyName, abilityName, model, properties) {
+  valueFor(abilityString, model, properties) {
+    let { abilityName, propertyName, subProperty } = this.parse(abilityString);
+
     let ability = this.abilityFor(abilityName, model, properties);
     let result = ability.getAbility(propertyName);
 
     ability.destroy();
 
-    return result;
+    if (!subProperty) {
+      return result;
+    }
+
+    return get(result, subProperty);
   },
 
   /**
@@ -71,8 +77,22 @@ export default Service.extend({
    * @return {Boolean}              value of ability converted to boolean
    */
   can(abilityString, model, properties) {
-    let { propertyName, abilityName } = this.parse(abilityString);
-    return !!this.valueFor(propertyName, abilityName, model, properties);
+    let { abilityName, propertyName, subProperty } = this.parse(abilityString);
+
+    assert(
+      `Using 'abilityString:subProperty' syntax is forbidden in can and cannot helpers, use ability helper instead`,
+      !subProperty
+    );
+
+    let result = this.valueFor(abilityString, model, properties);
+    if (typeof result === 'object') {
+      assert(
+        `Ability property ${propertyName} in '${abilityName}' is an object and must have a 'can' property`,
+        'can' in result
+      );
+      return !!result.can;
+    }
+    return !!result;
   },
 
   /**

--- a/addon/utils/normalize.js
+++ b/addon/utils/normalize.js
@@ -11,7 +11,8 @@ const stopWords = ['of', 'in', 'for', 'to', 'from', 'on', 'as'];
  * @return {Object}        extracted propertyName and abilityName
  */
 export default function (string) {
-  let parts = string.split(' ');
+  let [abilityString, subProperty] = string.split(':').map((s) => s.trim());
+  let parts = abilityString.split(' ');
   let abilityName = singularize(parts.pop());
   let last = parts[parts.length - 1];
 
@@ -20,6 +21,5 @@ export default function (string) {
   }
 
   let propertyName = camelize(parts.join(' '));
-
-  return { propertyName, abilityName };
+  return { subProperty, propertyName, abilityName };
 }

--- a/app/helpers/ability.js
+++ b/app/helpers/ability.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-can/helpers/ability';

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "ember-can",
       "version": "3.2.0",
       "license": "MIT",
       "dependencies": {

--- a/tests/integration/helpers/ability-test.js
+++ b/tests/integration/helpers/ability-test.js
@@ -1,0 +1,182 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { Ability } from 'ember-can';
+import { computed } from '@ember/object';
+import Service from '@ember/service';
+import { inject as service } from '@ember/service';
+import { run } from '@ember/runloop';
+
+module('Integration | Helper | ability', function (hooks) {
+  setupRenderingTest(hooks);
+
+  module('with subproperty access', function () {
+    test('it works with custom property parser', async function (assert) {
+      assert.expect(1);
+
+      this.owner.register(
+        'ability:post',
+        Ability.extend({
+          worksWell: computed('model', function () {
+            return { can: true, subProperty: 'prop' };
+          }),
+
+          parseProperty(propertyName) {
+            return propertyName; // without `can` prefix
+          },
+        })
+      );
+
+      await render(hbs`{{ability "works well post:subProperty"}}`);
+      assert.dom(this.element).hasText('prop');
+    });
+
+    test('it works without model', async function (assert) {
+      assert.expect(1);
+
+      this.owner.register(
+        'ability:post',
+        Ability.extend({
+          canWrite: computed('model', function () {
+            return { can: true, subProperty: 'prop' };
+          }),
+        })
+      );
+
+      await render(hbs`{{ability "write post:subProperty"}}`);
+      assert.dom(this.element).hasText('prop');
+    });
+
+    test('it can receives model', async function (assert) {
+      assert.expect(4);
+
+      this.owner.register(
+        'ability:post',
+        Ability.extend({
+          canWrite: computed('write', function () {
+            return { can: this.write, subProperty: 'prop' };
+          }),
+        })
+      );
+
+      await render(hbs`{{ability "write post:subProperty" model}}`);
+      assert.dom(this.element).hasText('prop');
+
+      this.set('model', { write: false });
+      assert.dom(this.element).hasText('prop');
+
+      this.set('model', { write: true });
+      assert.dom(this.element).hasText('prop');
+
+      this.set('model', null);
+      assert.dom(this.element).hasText('prop');
+    });
+
+    test('it works with default model', async function (assert) {
+      assert.expect(4);
+
+      this.owner.register(
+        'ability:post',
+        Ability.extend({
+          // eslint-disable-next-line ember/avoid-leaking-state-in-ember-objects
+          model: { write: true },
+
+          canWrite: computed('write', function () {
+            return { can: this.write, subProperty: 'prop' };
+          }).readOnly(),
+        })
+      );
+
+      await render(hbs`{{ability "write post:subProperty" model}}`);
+      assert.dom(this.element).hasText('prop');
+
+      this.set('model', undefined);
+      assert.dom(this.element).hasText('prop');
+
+      this.set('model', null);
+      assert.dom(this.element).hasText('prop');
+
+      this.set('model', { write: false });
+      assert.dom(this.element).hasText('prop');
+    });
+
+    test('it can receives properties', async function (assert) {
+      assert.expect(2);
+
+      this.owner.register(
+        'ability:post',
+        Ability.extend({
+          canWrite: computed('write', function () {
+            return { can: this.write, subProperty: 'prop' };
+          }).readOnly(),
+        })
+      );
+
+      this.set('write', false);
+      await render(hbs`{{ability "write post:subProperty" write=write}}`);
+      assert.dom(this.element).hasText('prop');
+
+      this.set('write', true);
+      assert.dom(this.element).hasText('prop');
+    });
+
+    test('it can receives model and properties', async function (assert) {
+      assert.expect(2);
+
+      this.owner.register(
+        'ability:post',
+        Ability.extend({
+          canWrite: computed('model.write', 'write', function () {
+            return {
+              can: this.model.write && this.write,
+              subProperty: 'prop',
+            };
+          }).readOnly(),
+        })
+      );
+
+      this.set('write', false);
+      this.set('model', { write: false });
+
+      await render(
+        hbs`{{ability "write post:subProperty" model write=this.write}}`
+      );
+
+      assert.dom(this.element).hasText('prop');
+
+      this.set('write', true);
+      this.set('model', { write: true });
+
+      assert.dom(this.element).hasText('prop');
+    });
+
+    test('it reacts on ability change', async function (assert) {
+      assert.expect(2);
+
+      this.owner.register(
+        'service:session',
+        Service.extend({
+          isLoggedIn: false,
+        })
+      );
+
+      this.owner.register(
+        'ability:post',
+        Ability.extend({
+          session: service(),
+
+          canWrite: computed('session.isLoggedIn', function () {
+            return { can: this.session.isLoggedIn, subProperty: 'prop' };
+          }),
+        })
+      );
+
+      await render(hbs`{{ability "write post:subProperty"}}`);
+      assert.dom(this.element).hasText('prop');
+
+      run(() => this.owner.lookup('service:session').set('isLoggedIn', true));
+      assert.dom(this.element).hasText('prop');
+    });
+  });
+});

--- a/tests/integration/helpers/can-test.js
+++ b/tests/integration/helpers/can-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, clearRender } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { Ability } from 'ember-can';
 import { computed } from '@ember/object';
@@ -10,6 +10,27 @@ import { run } from '@ember/runloop';
 
 module('Integration | Helper | can', function (hooks) {
   setupRenderingTest(hooks);
+
+  module('null propertyName guard', function () {
+    test('it does not crash when _removeAbilityObserver runs before any observer is registered', async function (assert) {
+      assert.expect(2);
+
+      this.owner.register(
+        'ability:post',
+        Ability.extend({
+          canWrite: true,
+        })
+      );
+
+      await render(hbs`{{if (can "write post") "true" "false"}}`);
+      assert
+        .dom(this.element)
+        .hasText('true', 'renders without crash on initial compute');
+
+      await clearRender();
+      assert.ok(true, 'destroy completed without crash');
+    });
+  });
 
   module('classic class', function () {
     test('it works with custom property parser', async function (assert) {

--- a/tests/unit/services/can-test.js
+++ b/tests/unit/services/can-test.js
@@ -7,16 +7,30 @@ module('Unit | Service | can', function (hooks) {
   setupTest(hooks);
 
   test('parse', function (assert) {
-    assert.expect(2);
+    assert.expect(4);
 
     let service = this.owner.lookup('service:can');
 
     assert.deepEqual(service.parse('manage members in project'), {
+      subProperty: undefined,
       propertyName: 'manageMembers',
       abilityName: 'project',
     });
 
     assert.deepEqual(service.parse('add tags to post'), {
+      subProperty: undefined,
+      propertyName: 'addTags',
+      abilityName: 'post',
+    });
+
+    assert.deepEqual(service.parse('manage members in project:prop'), {
+      subProperty: 'prop',
+      propertyName: 'manageMembers',
+      abilityName: 'project',
+    });
+
+    assert.deepEqual(service.parse('add tags to post:prop'), {
+      subProperty: 'prop',
       propertyName: 'addTags',
       abilityName: 'post',
     });
@@ -58,7 +72,7 @@ module('Unit | Service | can', function (hooks) {
     );
 
     assert.equal(
-      service.valueFor('touchThis', 'superModel', { yeah: 'Yeah!' }),
+      service.valueFor('touchThis in superModel', { yeah: 'Yeah!' }, 'Yaeh!'),
       'Yeah!'
     );
   });

--- a/tests/unit/utils/normalize-test.js
+++ b/tests/unit/utils/normalize-test.js
@@ -43,4 +43,12 @@ module('Unit | Util | normalize', function () {
     assert.equal(norm.propertyName, 'comment');
     assert.equal(norm.abilityName, 'issue');
   });
+
+  test('returns subproperty as well', function (assert) {
+    let norm = normalize('edit posts:prop');
+
+    assert.equal(norm.subProperty, 'prop');
+    assert.equal(norm.propertyName, 'edit');
+    assert.equal(norm.abilityName, 'post');
+  });
 });


### PR DESCRIPTION
## Summary

Fixes concordnow/atlas-bug-tracker#12

Patches `_removeAbilityObserver` in the Concord `ember-can` fork to add a null guard before calling `removeObserver`. When `this.propertyName` is null (initial state before any observer is registered, or after prior cleanup), the method now returns early instead of passing the invalid event name `ability.null:change` to Ember`s `deactivateObserver`, which crashes on `observer.count--`. Adds a regression test verifying no crash during initial compute and destroy lifecycle.

Fixes concordnow/atlas-bug-tracker#16

## Context

**WP-01** → WP-02 (2 total). This is the first of 2 work packages. WP-01 patches the ember-can fork and tags a new release. WP-02 (in `concordnow/concord-app-front`) updates the tarball reference to consume this fix.

## Decisions

- Guard covers the entire `_removeAbilityObserver` method body (removeObserver + ability.destroy + setProperties reset), not just the removeObserver call. When `propertyName` is null, `ability` is also null — guarding on `propertyName` protects all three operations.
- Regression test targets the specific crash scenario (initial compute where `_removeAbilityObserver` runs before any observer is registered), not a generic lifecycle test.
- Branch and tag pushed to remote during Code layer (not deferred to Delivery) because WP-02 consumes the tag via tarball URL — cross-repo dependency requires the tag to be available before WP-02 can execute.
- Reverted `package-lock.json` changes generated by `npm install` on Node 25/npm 11 — not in scope.

## Out of Scope

- **Upgrade ember-can to v8.0.0** — Major version with breaking API changes (126 invocations, 45 templates). Separate initiative if desired.
- **Missing anti-patterns file for concordnow/ember-can** — Small forked addon, no patterns file in `code-review-patterns/`.

## Changes

| File | Action | Purpose |
|---|---|---|
| `addon/helpers/ability.js` | Modified | Added early return when `this.propertyName === null` in `_removeAbilityObserver` |
| `tests/integration/helpers/can-test.js` | Modified | Added regression test for null propertyName crash scenario |

*Generated by Atlas · Run 2026-02-27-fix-ember-count-undefined*